### PR TITLE
Change UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+v0.1.0-alpha.1 (2022.04.04)
+- UI Changed (Ctrl + ... => (Ctrl or Alt) + ...)
+
 v0.1.0-alpha (2022.04.02)
-- reset version
+- Reset version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kkitahara/qc-tools",
-  "version": "0.1.0-alpha",
+  "version": "0.1.0-alpha.1",
   "description": "ECMAScript modules for manipulating quasicrystal structures.",
   "keywords": [
     "Crystallography",

--- a/src/qcweb2/core/core.js
+++ b/src/qcweb2/core/core.js
@@ -5038,11 +5038,11 @@ export class QCWeb2Core {
   }
 
   onDoubleClick (e) {
-    if (e.ctrlKey && !e.altKey && e.shiftKey) {
+    if ((e.ctrlKey || e.altKey) && e.shiftKey) {
       this.ui.ctrlShiftDoubleClicked = true
-    } else if (!e.ctrlKey && !e.altKey && e.shiftKey) {
+    } else if (!(e.ctrlKey || e.altKey) && e.shiftKey) {
       this.ui.shiftDoubleClicked = true
-    } else if (e.ctrlKey && !e.altKey && !e.shiftKey) {
+    } else if ((e.ctrlKey || e.altKey) && !e.shiftKey) {
       this.ui.ctrlDoubleClicked = true
     } else {
       // this.ui.doubleClicked = true
@@ -5053,7 +5053,7 @@ export class QCWeb2Core {
   onWheel (e) {
     if (e.shiftKey) {
       this.ui.shiftWheelDeltaY += e.deltaY
-    } else if (e.ctrlKey) {
+    } else if (e.ctrlKey || e.altKey) {
       this.ui.ctrlWheelDeltaY += e.deltaY
     } else {
       this.ui.wheelDeltaY += e.deltaY
@@ -5200,11 +5200,11 @@ export class QCWeb2Core {
     str += 'Shift + Wheel: move along the view direction\n'
     str += 'Shift + Double-click an atom: move such that the selected atom is at the centre\n'
     str += 'Shift + Double-click background: move slightly in a random direction in both parallel and perpendicular spaces\n'
-    str += 'Ctrl + Wheel: change the range of displaying the model\n'
-    str += 'Ctrl + Double-click an atom in parallel space: switch to the perpendicular space that contains the selected atom\n'
-    str += 'Ctrl + Double-click in perpendicular space: switch to the parallel space\n'
-    str += 'Ctrl + Shift + Double-click an atom: highlight the selected atom\n'
-    str += 'Ctrl + Shift + Double-click background: stop highlighting'
+    str += 'Ctrl (or Alt) + Wheel: change the range of displaying the model\n'
+    str += 'Ctrl (or Alt) + Double-click an atom in parallel space: switch to the perpendicular space that contains the selected atom\n'
+    str += 'Ctrl (or Alt) + Double-click in perpendicular space: switch to the parallel space\n'
+    str += 'Ctrl (or Alt) + Shift + Double-click an atom: highlight the selected atom\n'
+    str += 'Ctrl (or Alt) + Shift + Double-click background: stop highlighting'
     window.alert(str)
   }
 }


### PR DESCRIPTION
Ctrl + ... というコマンドを (Ctrl or Alt) + ... に変更。
* Chromebook で Alt + Click が右クリックとして認識されてしまう。
* 一方、MacOS では Ctrl + Click が右クリックとして認識されてしまう。
* それぞれ、逆を使う事で回避。いずれ全面的に見直した方が良いかも？