### PR TITLE
UI の更新（(Ctrl + Alt) + ... => (Ctrl + Alt + Meta) + ...）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v0.1.0-alpha.3 (2022.05.12)
+- UI Changed ((Ctrl or Alt) + ... => (Ctrl or Alt or Meta) + ...)
+
 v0.1.0-alpha.2 (2022.05.10)
 - Samples updated
 

--- a/examples/qcweb2.min.js
+++ b/examples/qcweb2.min.js
@@ -1010,7 +1010,6 @@ function Provider(_ref) {
       children = _ref.children;
   var contextValue = react_13(function () {
     var subscription = createSubscription(store);
-    subscription.onStateChange = subscription.notifyNestedSubs;
     return {
       store: store,
       subscription: subscription
@@ -1021,6 +1020,7 @@ function Provider(_ref) {
   }, [store]);
   useIsomorphicLayoutEffect(function () {
     var subscription = contextValue.subscription;
+    subscription.onStateChange = subscription.notifyNestedSubs;
     subscription.trySubscribe();
 
     if (previousState !== store.getState()) {
@@ -19541,11 +19541,11 @@ class QCWeb2Core {
   }
 
   onDoubleClick (e) {
-    if ((e.ctrlKey || e.altKey) && e.shiftKey) {
+    if ((e.ctrlKey || e.altKey || e.metaKey) && e.shiftKey) {
       this.ui.ctrlShiftDoubleClicked = true;
-    } else if (!(e.ctrlKey || e.altKey) && e.shiftKey) {
+    } else if (!(e.ctrlKey || e.altKey || e.metaKey) && e.shiftKey) {
       this.ui.shiftDoubleClicked = true;
-    } else if ((e.ctrlKey || e.altKey) && !e.shiftKey) {
+    } else if ((e.ctrlKey || e.altKey || e.metaKey) && !e.shiftKey) {
       this.ui.ctrlDoubleClicked = true;
     }
     e.preventDefault();
@@ -19554,7 +19554,7 @@ class QCWeb2Core {
   onWheel (e) {
     if (e.shiftKey) {
       this.ui.shiftWheelDeltaY += e.deltaY;
-    } else if (e.ctrlKey || e.altKey) {
+    } else if (e.ctrlKey || e.altKey || e.metaKey) {
       this.ui.ctrlWheelDeltaY += e.deltaY;
     } else {
       this.ui.wheelDeltaY += e.deltaY;
@@ -19701,11 +19701,11 @@ class QCWeb2Core {
     str += 'Shift + Wheel: move along the view direction\n';
     str += 'Shift + Double-click an atom: move such that the selected atom is at the centre\n';
     str += 'Shift + Double-click background: move slightly in a random direction in both parallel and perpendicular spaces\n';
-    str += 'Ctrl (or Alt) + Wheel: change the range of displaying the model\n';
-    str += 'Ctrl (or Alt) + Double-click an atom in parallel space: switch to the perpendicular space that contains the selected atom\n';
-    str += 'Ctrl (or Alt) + Double-click in perpendicular space: switch to the parallel space\n';
-    str += 'Ctrl (or Alt) + Shift + Double-click an atom: highlight the selected atom\n';
-    str += 'Ctrl (or Alt) + Shift + Double-click background: stop highlighting';
+    str += 'Ctrl (or Alt or Meta) + Wheel: change the range of displaying the model\n';
+    str += 'Ctrl (or Alt or Meta) + Double-click an atom in parallel space: switch to the perpendicular space that contains the selected atom\n';
+    str += 'Ctrl (or Alt or Meta) + Double-click in perpendicular space: switch to the parallel space\n';
+    str += 'Ctrl (or Alt or Meta) + Shift + Double-click an atom: highlight the selected atom\n';
+    str += 'Ctrl (or Alt or Meta) + Shift + Double-click background: stop highlighting';
     window.alert(str);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kkitahara/qc-tools",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kkitahara/qc-tools",
-      "version": "0.1.0-alpha.1",
+      "version": "0.1.0-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@kkitahara/unicode-tools": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kkitahara/qc-tools",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "ECMAScript modules for manipulating quasicrystal structures.",
   "keywords": [
     "Crystallography",

--- a/src/qcweb2/core/core.js
+++ b/src/qcweb2/core/core.js
@@ -5038,11 +5038,11 @@ export class QCWeb2Core {
   }
 
   onDoubleClick (e) {
-    if ((e.ctrlKey || e.altKey) && e.shiftKey) {
+    if ((e.ctrlKey || e.altKey || e.metaKey) && e.shiftKey) {
       this.ui.ctrlShiftDoubleClicked = true
-    } else if (!(e.ctrlKey || e.altKey) && e.shiftKey) {
+    } else if (!(e.ctrlKey || e.altKey || e.metaKey) && e.shiftKey) {
       this.ui.shiftDoubleClicked = true
-    } else if ((e.ctrlKey || e.altKey) && !e.shiftKey) {
+    } else if ((e.ctrlKey || e.altKey || e.metaKey) && !e.shiftKey) {
       this.ui.ctrlDoubleClicked = true
     } else {
       // this.ui.doubleClicked = true
@@ -5053,7 +5053,7 @@ export class QCWeb2Core {
   onWheel (e) {
     if (e.shiftKey) {
       this.ui.shiftWheelDeltaY += e.deltaY
-    } else if (e.ctrlKey || e.altKey) {
+    } else if (e.ctrlKey || e.altKey || e.metaKey) {
       this.ui.ctrlWheelDeltaY += e.deltaY
     } else {
       this.ui.wheelDeltaY += e.deltaY
@@ -5200,11 +5200,11 @@ export class QCWeb2Core {
     str += 'Shift + Wheel: move along the view direction\n'
     str += 'Shift + Double-click an atom: move such that the selected atom is at the centre\n'
     str += 'Shift + Double-click background: move slightly in a random direction in both parallel and perpendicular spaces\n'
-    str += 'Ctrl (or Alt) + Wheel: change the range of displaying the model\n'
-    str += 'Ctrl (or Alt) + Double-click an atom in parallel space: switch to the perpendicular space that contains the selected atom\n'
-    str += 'Ctrl (or Alt) + Double-click in perpendicular space: switch to the parallel space\n'
-    str += 'Ctrl (or Alt) + Shift + Double-click an atom: highlight the selected atom\n'
-    str += 'Ctrl (or Alt) + Shift + Double-click background: stop highlighting'
+    str += 'Ctrl (or Alt or Meta) + Wheel: change the range of displaying the model\n'
+    str += 'Ctrl (or Alt or Meta) + Double-click an atom in parallel space: switch to the perpendicular space that contains the selected atom\n'
+    str += 'Ctrl (or Alt or Meta) + Double-click in perpendicular space: switch to the parallel space\n'
+    str += 'Ctrl (or Alt or Meta) + Shift + Double-click an atom: highlight the selected atom\n'
+    str += 'Ctrl (or Alt or Meta) + Shift + Double-click background: stop highlighting'
     window.alert(str)
   }
 }


### PR DESCRIPTION
Windwos 版の Chrome などで、Ctrl + wheel がブラウザの画面拡大・縮小と競合してしまう問題に対する暫定的な対処。
Wheel event を非passiveにすれば良いが、React側で非passiveにするオプションを提供していないので、修正が少し大変そう。
取り急ぎ、代替コマンドとして、Meta + Wheel を追加。
ただし、Meta + Wheel は Metaキーを離したときにWindowsメニューが開いてしまうので、それほど具合は良くない。あくまで応急処置。